### PR TITLE
Feature better replace

### DIFF
--- a/DCReplace/Config.cs
+++ b/DCReplace/Config.cs
@@ -1,9 +1,13 @@
 ﻿using Exiled.API.Interfaces;
+using System.ComponentModel;
 
 namespace DCReplace
 {
 	public class Config : IConfig
 	{
 		public bool IsEnabled { get; set; } = true;
+
+		[Description("The message to show debug messages.")]
+		public bool debugEnabled { get; set; } = false;
 	}
 }

--- a/DCReplace/Config.cs
+++ b/DCReplace/Config.cs
@@ -1,5 +1,7 @@
 ﻿using Exiled.API.Interfaces;
+using System.Collections.Generic;
 using System.ComponentModel;
+using static SharedLogicOrchestrator.DebugFilters;
 
 namespace DCReplace
 {
@@ -7,7 +9,16 @@ namespace DCReplace
 	{
 		public bool IsEnabled { get; set; } = true;
 
-		[Description("The message to show debug messages.")]
+		[Description("The message to show most debug messages.")]
 		public bool debugEnabled { get; set; } = false;
+
+		public Dictionary<DebugFilter, bool> DebugFilters { get; set; } =
+		   new Dictionary<DebugFilter, bool> {
+
+			   {  DebugFilter.All , false },
+			   {  DebugFilter.Fine , false },
+			   {  DebugFilter.Finer , false },
+			   {  DebugFilter.Finest , false }
+		   };
 	}
 }

--- a/DCReplace/DCReplace.cs
+++ b/DCReplace/DCReplace.cs
@@ -8,6 +8,8 @@ namespace DCReplace
 
 		private bool state = false;
 
+		internal static DCReplace instance;
+
 		public override void OnEnabled()
 		{
 			if (state) return;
@@ -15,6 +17,9 @@ namespace DCReplace
 			if (!Config.IsEnabled) return;
 
 			ev = new EventHandlers();
+
+			instance = this;
+
 
 			Exiled.Events.Handlers.Player.Left += ev.OnPlayerLeave;
 			Exiled.Events.Handlers.Scp106.Containing += ev.OnContain106;
@@ -41,7 +46,7 @@ namespace DCReplace
 			Exiled.Events.Handlers.Scp106.Containing -= ev.OnContain106;
 
 			ev = null;
-
+			instance = null;
 			state = false;
 			base.OnDisabled();
 		}

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -62,6 +62,7 @@ namespace DCReplace
 		/// Firstly creates a reference to the plugin we are trying to get. If it doesn't already exist.
 		/// Then uses the plugin to call the required API's to get 966 information. Saves player
 		/// reference as private variable. Non-static. Under assumption of only 1 966 allowed at one time. 
+		/// Assumption that API will send back player. Original implementation was some sort of string. 
 		/// </summary>
 		private void TryGet966()
 		{

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -310,7 +310,6 @@ namespace DCReplace
 				scp079lvl = prevInventory.scp079lvl;
 				scp079exp = prevInventory.scp079exp;
 			}
-
 			Timing.CallDelayed(0.5f, () =>
 			{
 				replacement.ResetInventory(prevInventory.Items.Select(x => x.Type).ToList());

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -35,14 +35,13 @@ namespace DCReplace
 
 			if (scp035Plugin != null)
 			{
-				Log.Info("Plugin already loaded, just going to grab our needed func call");
+
 				//Under assumption of only 1 035 allowed at one time. 
 				scp035PlayerReference = (Player)scp035Plugin?.Assembly?.GetType("scp035.API.Scp035Data")?.GetMethod("GetScp035", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null);
 				return;
 			}
 
 
-			Log.Info("Plugin not already loaded");
 
 			try
 			{
@@ -149,16 +148,16 @@ namespace DCReplace
 			bool is966 = false;
 			if (isContain106 && player.Role == RoleType.Scp106) return;
 			Dictionary<Player, bool> spies = null;
-			Log.Info("uhhh");
+
 			try
 			{
 
 				TryGet035();
-				Log.Info("We got some information for 035 hopefully");
+
 				//May want to consider by nickname or something.
 				is035 = scp035PlayerReference != null && scp035PlayerReference == player;
 				string data = scp035PlayerReference != null ? scp035PlayerReference.Nickname : "Data returned null";
-				Log.Info($"Was 035 null: {!is035} and if it wasn't what was result: {data}");
+
 			}
 			catch (Exception x)
 			{
@@ -203,8 +202,7 @@ namespace DCReplace
 			{
 				// Have to do this early
 				var inventory = player.Items.Select(x => x.Type).ToList();
-				Log.Info(inventory);
-				Log.Info("Going to clear inventory");
+
 				player.ClearInventory();
 
 				PositionsToSpawn.Add(replacement, player.Position);

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -2,6 +2,8 @@
 using Exiled.API.Features;
 using Exiled.Events.EventArgs;
 using Exiled.Loader;
+using InventorySystem.Items;
+using InventorySystem.Items.Usables.Scp330;
 using MEC;
 using SharedLogicOrchestrator;
 using System;
@@ -314,6 +316,12 @@ namespace DCReplace
 			{
 				replacement.ResetInventory(prevInventory.Items.Select(x => x.Type).ToList());
 
+
+
+
+
+
+
 				replacement.Health = prevInventory.Health;
 
 				foreach (ItemType ammoType in prevInventory.Ammo.Keys)
@@ -321,8 +329,28 @@ namespace DCReplace
 					replacement.Inventory.UserInventory.ReserveAmmo[ammoType] = prevInventory.Ammo[ammoType];
 					replacement.Inventory.SendAmmoNextFrame = true;
 				}
+
+				Timing.CallDelayed(0.5f, () =>
+				{
+					foreach (KeyValuePair<ushort, ItemBase> item in replacement.Inventory.UserInventory.Items)
+					{
+						Scp330Bag scp330Bag;
+						if ((object)(scp330Bag = (item.Value as Scp330Bag)) != null)
+						{
+							scp330Bag.Candies.Clear();
+							scp330Bag.Candies.AddRange(prevInventory.currentCandies);
+							scp330Bag.ServerConfirmAcqusition();
+						}
+					}
+
+				});
+
+
 				replacement.Broadcast(5, "<i>You have replaced a player who has disconnected.</i>");
 			});
+
+
+
 		}
 
 

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -23,11 +23,6 @@ namespace DCReplace
 		private Player scp966PlayerReference;
 		private Exiled.API.Interfaces.IPlugin<Exiled.API.Interfaces.IConfig> scp966Plugin;
 
-		/// <summary>
-		/// Firstly creates a reference to the plugin we are trying to get. If it doesn't already exist.
-		/// Then uses the plugin to call the required API's to get 035 information. Saves player
-		/// reference as private variable. Non-static. Under assumption of only 1 035's allowed at one time. 
-		/// </summary>
 		private void TryGet035()
 		{
 
@@ -45,8 +40,11 @@ namespace DCReplace
 
 			try
 			{
+
 				//Under assumption of only 1 035 allowed at one time. 
+
 				scp035Plugin = Loader.Plugins.FirstOrDefault(pl => pl.Name == "scp035");
+
 				scp035PlayerReference = (Player)scp035Plugin?.Assembly?.GetType("scp035.API.Scp035Data")?.GetMethod("GetScp035", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null);
 			}
 			catch (Exception e)
@@ -55,42 +53,6 @@ namespace DCReplace
 			}
 
 			return;
-		}
-
-
-		/// <summary>
-		/// Firstly creates a reference to the plugin we are trying to get. If it doesn't already exist.
-		/// Then uses the plugin to call the required API's to get 966 information. Saves player
-		/// reference as private variable. Non-static. Under assumption of only 1 966 allowed at one time. 
-		/// Assumption that API will send back player. Original implementation was some sort of string. 
-		/// </summary>
-		private void TryGet966()
-		{
-			/*
-			 * 	
-			 * 	if ((string)Loader.Plugins.First(pl => pl.Name == "scp966")?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null) == player.UserId)
-				{
-					Loader.Plugins.First(pl => pl.Name == "scp966").Assembly.GetType("scp966.API.Scp966API").GetMethod("Spawn966", BindingFlags.Public | BindingFlags.Static).Invoke(null, new object[] { replacement });
-				}
-
-			*/
-			if (scp966Plugin != null)
-			{
-				scp966PlayerReference = ((Player)scp966Plugin?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
-				return;
-			}
-
-			try
-			{
-
-				scp966Plugin = Loader.Plugins.FirstOrDefault(pl => pl.Name == "scp966");
-
-				scp966PlayerReference = (Player)(scp966Plugin?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
-			}
-			catch (Exception e)
-			{
-				Log.Debug("Failed getting 966s: " + e);
-			}
 		}
 
 		private List<Player> TryGetSH()
@@ -154,11 +116,10 @@ namespace DCReplace
 			{
 
 				TryGet035();
-
 				//May want to consider by nickname or something.
 				is035 = scp035PlayerReference != null && scp035PlayerReference == player;
 				string data = scp035PlayerReference != null ? scp035PlayerReference.Nickname : "Data returned null";
-
+				Log.Info($"Was 035 null: {!is035} and if it wasn't what was result: {data}");
 			}
 			catch (Exception x)
 			{
@@ -203,6 +164,7 @@ namespace DCReplace
 			{
 				// Have to do this early
 				var inventory = player.Items.Select(x => x.Type).ToList();
+
 
 				player.ClearInventory();
 
@@ -279,6 +241,35 @@ namespace DCReplace
 			}
 		}
 
+		private void TryGet966()
+		{
+			/*
+			 * 	
+			 * 	if ((string)Loader.Plugins.First(pl => pl.Name == "scp966")?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null) == player.UserId)
+				{
+					Loader.Plugins.First(pl => pl.Name == "scp966").Assembly.GetType("scp966.API.Scp966API").GetMethod("Spawn966", BindingFlags.Public | BindingFlags.Static).Invoke(null, new object[] { replacement });
+				}
+
+			*/
+			if (scp966Plugin != null)
+			{
+				scp966PlayerReference = ((Player)Loader.Plugins.First(pl => pl.Name == "scp966")?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
+				return;
+			}
+
+			try
+			{
+				if (scp966Plugin == null)
+				{
+					scp966Plugin = (Exiled.API.Interfaces.IPlugin<Exiled.API.Interfaces.IConfig>)Loader.Plugins.FirstOrDefault(pl => pl.Name == "scp966");
+				}
+				scp966PlayerReference = (Player)(scp966Plugin?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
+			}
+			catch (Exception e)
+			{
+				Log.Debug("Failed getting 966s: " + e);
+			}
+		}
 
 		public void OnRoundStart()
 		{

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -75,7 +75,7 @@ namespace DCReplace
 			*/
 			if (scp966Plugin != null)
 			{
-				scp966PlayerReference = ((Player)Loader.Plugins.First(pl => pl.Name == "scp966")?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
+				scp966PlayerReference = ((Player)scp966Plugin?.Assembly?.GetType("scp966.API.Scp966API")?.GetMethod("GetLastScp966", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null));
 				return;
 			}
 

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -340,6 +340,7 @@ namespace DCReplace
 							scp330Bag.Candies.Clear();
 							scp330Bag.Candies.AddRange(prevInventory.currentCandies);
 							scp330Bag.ServerConfirmAcqusition();
+							break;
 						}
 					}
 

--- a/DCReplace/UtilityInformation/UtilityInfo.cs
+++ b/DCReplace/UtilityInformation/UtilityInfo.cs
@@ -1,0 +1,19 @@
+﻿namespace DCReplace.UtilityInformation
+{
+	public class UtilityInfo
+	{
+		/// <summary>
+		/// The type of player we are replacing
+		/// </summary>
+		public enum replacementType : ushort
+		{
+			Unknown = 0,
+			NonUniqueScp = 1,
+			Scp035 = 2,
+			Serpents = 3,
+			Spies = 4,
+			Scp966 = 5
+		}
+
+	}
+}


### PR DESCRIPTION
I am suggesting a new way of handling replacement of players, allowing the server to wait for a replacement - also keeps track of player data without keeping player object. You do need https://github.com/Undid-Iridium/SharedLogicOrchestrator so I didn't have to repeat logic.